### PR TITLE
First implementation of sliding item, updating api key

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,4 @@
 src/models
+src/models/models
+
+amplify-codegen-temp/models/models

--- a/amplify/backend/api/OneRep/cli-inputs.json
+++ b/amplify/backend/api/OneRep/cli-inputs.json
@@ -5,8 +5,9 @@
     "serviceName": "AppSync",
     "defaultAuthType": {
       "mode": "API_KEY",
-      "keyDescription": "api key description",
-      "expirationTime": 30
+      "expirationTime": 365,
+      "apiKeyExpirationDate": "2024-10-18T03:29:48.996Z",
+      "keyDescription": "onerep3"
     },
     "additionalAuthTypes": [
       {

--- a/amplify/backend/api/OneRep/parameters.json
+++ b/amplify/backend/api/OneRep/parameters.json
@@ -2,5 +2,6 @@
   "AppSyncApiName": "OneRep",
   "DynamoDBBillingMode": "PAY_PER_REQUEST",
   "DynamoDBEnableServerSideEncryption": false,
-  "AuthModeLastUpdated": "2023-01-12T04:53:28.807Z"
+  "AuthModeLastUpdated": "2023-10-19T02:29:41.036Z",
+  "CreateAPIKey": 1
 }

--- a/amplify/backend/backend-config.json
+++ b/amplify/backend/backend-config.json
@@ -11,8 +11,9 @@
           ],
           "defaultAuthentication": {
             "apiKeyConfig": {
-              "apiKeyExpirationDays": 30,
-              "description": "api key description"
+              "apiKeyExpirationDate": "2024-10-18T03:29:48.996Z",
+              "apiKeyExpirationDays": 365,
+              "description": "onerep3"
             },
             "authenticationType": "API_KEY"
           }

--- a/amplify/cli.json
+++ b/amplify/cli.json
@@ -1,60 +1,62 @@
 {
-    "features": {
-        "graphqltransformer": {
-            "addmissingownerfields": true,
-            "improvepluralization": false,
-            "validatetypenamereservedwords": true,
-            "useexperimentalpipelinedtransformer": true,
-            "enableiterativegsiupdates": true,
-            "secondarykeyasgsi": true,
-            "skipoverridemutationinputtypes": true,
-            "transformerversion": 2,
-            "suppressschemamigrationprompt": true,
-            "securityenhancementnotification": false,
-            "showfieldauthnotification": false,
-            "usesubusernamefordefaultidentityclaim": true,
-            "usefieldnameforprimarykeyconnectionfield": false,
-            "enableautoindexquerynames": true,
-            "respectprimarykeyattributesonconnectionfield": true,
-            "shoulddeepmergedirectiveconfigdefaults": false,
-            "populateownerfieldforstaticgroupauth": true
-        },
-        "frontend-ios": {
-            "enablexcodeintegration": true
-        },
-        "auth": {
-            "enablecaseinsensitivity": true,
-            "useinclusiveterminology": true,
-            "breakcirculardependency": true,
-            "forcealiasattributes": false,
-            "useenabledmfas": true
-        },
-        "codegen": {
-            "useappsyncmodelgenplugin": true,
-            "usedocsgeneratorplugin": true,
-            "usetypesgeneratorplugin": true,
-            "cleangeneratedmodelsdirectory": true,
-            "retaincasestyle": true,
-            "addtimestampfields": true,
-            "handlelistnullabilitytransparently": true,
-            "emitauthprovider": true,
-            "generateindexrules": true,
-            "enabledartnullsafety": true
-        },
-        "appsync": {
-            "generategraphqlpermissions": true
-        },
-        "latestregionsupport": {
-            "pinpoint": 1,
-            "translate": 1,
-            "transcribe": 1,
-            "rekognition": 1,
-            "textract": 1,
-            "comprehend": 1
-        },
-        "project": {
-            "overrides": true
-        }
+  "features": {
+    "graphqltransformer": {
+      "addmissingownerfields": true,
+      "improvepluralization": false,
+      "validatetypenamereservedwords": true,
+      "useexperimentalpipelinedtransformer": true,
+      "enableiterativegsiupdates": true,
+      "secondarykeyasgsi": true,
+      "skipoverridemutationinputtypes": true,
+      "transformerversion": 2,
+      "suppressschemamigrationprompt": true,
+      "securityenhancementnotification": false,
+      "showfieldauthnotification": false,
+      "usesubusernamefordefaultidentityclaim": true,
+      "usefieldnameforprimarykeyconnectionfield": false,
+      "enableautoindexquerynames": true,
+      "respectprimarykeyattributesonconnectionfield": true,
+      "shoulddeepmergedirectiveconfigdefaults": false,
+      "populateownerfieldforstaticgroupauth": true
     },
-    "debug": {}
+    "frontend-ios": {
+      "enablexcodeintegration": true
+    },
+    "auth": {
+      "enablecaseinsensitivity": true,
+      "useinclusiveterminology": true,
+      "breakcirculardependency": true,
+      "forcealiasattributes": false,
+      "useenabledmfas": true
+    },
+    "codegen": {
+      "useappsyncmodelgenplugin": true,
+      "usedocsgeneratorplugin": true,
+      "usetypesgeneratorplugin": true,
+      "cleangeneratedmodelsdirectory": true,
+      "retaincasestyle": true,
+      "addtimestampfields": true,
+      "handlelistnullabilitytransparently": true,
+      "emitauthprovider": true,
+      "generateindexrules": true,
+      "enabledartnullsafety": true
+    },
+    "appsync": {
+      "generategraphqlpermissions": true
+    },
+    "latestregionsupport": {
+      "pinpoint": 1,
+      "translate": 1,
+      "transcribe": 1,
+      "rekognition": 1,
+      "textract": 1,
+      "comprehend": 1
+    },
+    "project": {
+      "overrides": true
+    }
+  },
+  "debug": {
+    "shareProjectConfig": false
+  }
 }

--- a/src/API.ts
+++ b/src/API.ts
@@ -17,6 +17,7 @@ export type ModelEntryConditionInput = {
   and?: Array< ModelEntryConditionInput | null > | null,
   or?: Array< ModelEntryConditionInput | null > | null,
   not?: ModelEntryConditionInput | null,
+  _deleted?: ModelBooleanInput | null,
 };
 
 export type ModelIntInput = {
@@ -87,6 +88,13 @@ export type ModelIDInput = {
   size?: ModelSizeInput | null,
 };
 
+export type ModelBooleanInput = {
+  ne?: boolean | null,
+  eq?: boolean | null,
+  attributeExists?: boolean | null,
+  attributeType?: ModelAttributeTypes | null,
+};
+
 export type Entry = {
   __typename: "Entry",
   id: string,
@@ -126,6 +134,7 @@ export type ModelExerciseConditionInput = {
   and?: Array< ModelExerciseConditionInput | null > | null,
   or?: Array< ModelExerciseConditionInput | null > | null,
   not?: ModelExerciseConditionInput | null,
+  _deleted?: ModelBooleanInput | null,
 };
 
 export type Exercise = {
@@ -168,6 +177,7 @@ export type ModelEntryFilterInput = {
   and?: Array< ModelEntryFilterInput | null > | null,
   or?: Array< ModelEntryFilterInput | null > | null,
   not?: ModelEntryFilterInput | null,
+  _deleted?: ModelBooleanInput | null,
 };
 
 export enum ModelSortDirection {
@@ -183,6 +193,7 @@ export type ModelExerciseFilterInput = {
   and?: Array< ModelExerciseFilterInput | null > | null,
   or?: Array< ModelExerciseFilterInput | null > | null,
   not?: ModelExerciseFilterInput | null,
+  _deleted?: ModelBooleanInput | null,
 };
 
 export type ModelExerciseConnection = {
@@ -199,6 +210,7 @@ export type ModelSubscriptionEntryFilterInput = {
   exerciseID?: ModelSubscriptionIDInput | null,
   and?: Array< ModelSubscriptionEntryFilterInput | null > | null,
   or?: Array< ModelSubscriptionEntryFilterInput | null > | null,
+  _deleted?: ModelBooleanInput | null,
 };
 
 export type ModelSubscriptionIDInput = {
@@ -249,6 +261,7 @@ export type ModelSubscriptionExerciseFilterInput = {
   total?: ModelSubscriptionIntInput | null,
   and?: Array< ModelSubscriptionExerciseFilterInput | null > | null,
   or?: Array< ModelSubscriptionExerciseFilterInput | null > | null,
+  _deleted?: ModelBooleanInput | null,
 };
 
 export type CreateEntryMutationVariables = {

--- a/src/graphql/mutations.ts
+++ b/src/graphql/mutations.ts
@@ -2,120 +2,147 @@
 /* eslint-disable */
 // this is an auto generated file. This will be overwritten
 
-export const createEntry = /* GraphQL */ `
-  mutation CreateEntry(
-    $input: CreateEntryInput!
-    $condition: ModelEntryConditionInput
-  ) {
-    createEntry(input: $input, condition: $condition) {
-      id
-      entered
-      date
-      exerciseID
-      createdAt
-      updatedAt
-      _version
-      _deleted
-      _lastChangedAt
-    }
+import * as APITypes from "../API";
+type GeneratedMutation<InputType, OutputType> = string & {
+  __generatedMutationInput: InputType;
+  __generatedMutationOutput: OutputType;
+};
+
+export const createEntry = /* GraphQL */ `mutation CreateEntry(
+  $input: CreateEntryInput!
+  $condition: ModelEntryConditionInput
+) {
+  createEntry(input: $input, condition: $condition) {
+    id
+    entered
+    date
+    exerciseID
+    createdAt
+    updatedAt
+    _version
+    _deleted
+    _lastChangedAt
+    __typename
   }
-`;
-export const updateEntry = /* GraphQL */ `
-  mutation UpdateEntry(
-    $input: UpdateEntryInput!
-    $condition: ModelEntryConditionInput
-  ) {
-    updateEntry(input: $input, condition: $condition) {
-      id
-      entered
-      date
-      exerciseID
-      createdAt
-      updatedAt
-      _version
-      _deleted
-      _lastChangedAt
-    }
+}
+` as GeneratedMutation<
+  APITypes.CreateEntryMutationVariables,
+  APITypes.CreateEntryMutation
+>;
+export const updateEntry = /* GraphQL */ `mutation UpdateEntry(
+  $input: UpdateEntryInput!
+  $condition: ModelEntryConditionInput
+) {
+  updateEntry(input: $input, condition: $condition) {
+    id
+    entered
+    date
+    exerciseID
+    createdAt
+    updatedAt
+    _version
+    _deleted
+    _lastChangedAt
+    __typename
   }
-`;
-export const deleteEntry = /* GraphQL */ `
-  mutation DeleteEntry(
-    $input: DeleteEntryInput!
-    $condition: ModelEntryConditionInput
-  ) {
-    deleteEntry(input: $input, condition: $condition) {
-      id
-      entered
-      date
-      exerciseID
-      createdAt
-      updatedAt
-      _version
-      _deleted
-      _lastChangedAt
-    }
+}
+` as GeneratedMutation<
+  APITypes.UpdateEntryMutationVariables,
+  APITypes.UpdateEntryMutation
+>;
+export const deleteEntry = /* GraphQL */ `mutation DeleteEntry(
+  $input: DeleteEntryInput!
+  $condition: ModelEntryConditionInput
+) {
+  deleteEntry(input: $input, condition: $condition) {
+    id
+    entered
+    date
+    exerciseID
+    createdAt
+    updatedAt
+    _version
+    _deleted
+    _lastChangedAt
+    __typename
   }
-`;
-export const createExercise = /* GraphQL */ `
-  mutation CreateExercise(
-    $input: CreateExerciseInput!
-    $condition: ModelExerciseConditionInput
-  ) {
-    createExercise(input: $input, condition: $condition) {
-      id
-      title
-      total
-      Entries {
-        nextToken
-        startedAt
-      }
-      createdAt
-      updatedAt
-      _version
-      _deleted
-      _lastChangedAt
+}
+` as GeneratedMutation<
+  APITypes.DeleteEntryMutationVariables,
+  APITypes.DeleteEntryMutation
+>;
+export const createExercise = /* GraphQL */ `mutation CreateExercise(
+  $input: CreateExerciseInput!
+  $condition: ModelExerciseConditionInput
+) {
+  createExercise(input: $input, condition: $condition) {
+    id
+    title
+    total
+    Entries {
+      nextToken
+      startedAt
+      __typename
     }
+    createdAt
+    updatedAt
+    _version
+    _deleted
+    _lastChangedAt
+    __typename
   }
-`;
-export const updateExercise = /* GraphQL */ `
-  mutation UpdateExercise(
-    $input: UpdateExerciseInput!
-    $condition: ModelExerciseConditionInput
-  ) {
-    updateExercise(input: $input, condition: $condition) {
-      id
-      title
-      total
-      Entries {
-        nextToken
-        startedAt
-      }
-      createdAt
-      updatedAt
-      _version
-      _deleted
-      _lastChangedAt
+}
+` as GeneratedMutation<
+  APITypes.CreateExerciseMutationVariables,
+  APITypes.CreateExerciseMutation
+>;
+export const updateExercise = /* GraphQL */ `mutation UpdateExercise(
+  $input: UpdateExerciseInput!
+  $condition: ModelExerciseConditionInput
+) {
+  updateExercise(input: $input, condition: $condition) {
+    id
+    title
+    total
+    Entries {
+      nextToken
+      startedAt
+      __typename
     }
+    createdAt
+    updatedAt
+    _version
+    _deleted
+    _lastChangedAt
+    __typename
   }
-`;
-export const deleteExercise = /* GraphQL */ `
-  mutation DeleteExercise(
-    $input: DeleteExerciseInput!
-    $condition: ModelExerciseConditionInput
-  ) {
-    deleteExercise(input: $input, condition: $condition) {
-      id
-      title
-      total
-      Entries {
-        nextToken
-        startedAt
-      }
-      createdAt
-      updatedAt
-      _version
-      _deleted
-      _lastChangedAt
+}
+` as GeneratedMutation<
+  APITypes.UpdateExerciseMutationVariables,
+  APITypes.UpdateExerciseMutation
+>;
+export const deleteExercise = /* GraphQL */ `mutation DeleteExercise(
+  $input: DeleteExerciseInput!
+  $condition: ModelExerciseConditionInput
+) {
+  deleteExercise(input: $input, condition: $condition) {
+    id
+    title
+    total
+    Entries {
+      nextToken
+      startedAt
+      __typename
     }
+    createdAt
+    updatedAt
+    _version
+    _deleted
+    _lastChangedAt
+    __typename
   }
-`;
+}
+` as GeneratedMutation<
+  APITypes.DeleteExerciseMutationVariables,
+  APITypes.DeleteExerciseMutation
+>;

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -2,9 +2,34 @@
 /* eslint-disable */
 // this is an auto generated file. This will be overwritten
 
-export const getEntry = /* GraphQL */ `
-  query GetEntry($id: ID!) {
-    getEntry(id: $id) {
+import * as APITypes from "../API";
+type GeneratedQuery<InputType, OutputType> = string & {
+  __generatedQueryInput: InputType;
+  __generatedQueryOutput: OutputType;
+};
+
+export const getEntry = /* GraphQL */ `query GetEntry($id: ID!) {
+  getEntry(id: $id) {
+    id
+    entered
+    date
+    exerciseID
+    createdAt
+    updatedAt
+    _version
+    _deleted
+    _lastChangedAt
+    __typename
+  }
+}
+` as GeneratedQuery<APITypes.GetEntryQueryVariables, APITypes.GetEntryQuery>;
+export const listEntries = /* GraphQL */ `query ListEntries(
+  $filter: ModelEntryFilterInput
+  $limit: Int
+  $nextToken: String
+) {
+  listEntries(filter: $filter, limit: $limit, nextToken: $nextToken) {
+    items {
       id
       entered
       date
@@ -14,157 +39,162 @@ export const getEntry = /* GraphQL */ `
       _version
       _deleted
       _lastChangedAt
+      __typename
     }
+    nextToken
+    startedAt
+    __typename
   }
-`;
-export const listEntries = /* GraphQL */ `
-  query ListEntries(
-    $filter: ModelEntryFilterInput
-    $limit: Int
-    $nextToken: String
+}
+` as GeneratedQuery<
+  APITypes.ListEntriesQueryVariables,
+  APITypes.ListEntriesQuery
+>;
+export const syncEntries = /* GraphQL */ `query SyncEntries(
+  $filter: ModelEntryFilterInput
+  $limit: Int
+  $nextToken: String
+  $lastSync: AWSTimestamp
+) {
+  syncEntries(
+    filter: $filter
+    limit: $limit
+    nextToken: $nextToken
+    lastSync: $lastSync
   ) {
-    listEntries(filter: $filter, limit: $limit, nextToken: $nextToken) {
-      items {
-        id
-        entered
-        date
-        exerciseID
-        createdAt
-        updatedAt
-        _version
-        _deleted
-        _lastChangedAt
-      }
-      nextToken
-      startedAt
-    }
-  }
-`;
-export const syncEntries = /* GraphQL */ `
-  query SyncEntries(
-    $filter: ModelEntryFilterInput
-    $limit: Int
-    $nextToken: String
-    $lastSync: AWSTimestamp
-  ) {
-    syncEntries(
-      filter: $filter
-      limit: $limit
-      nextToken: $nextToken
-      lastSync: $lastSync
-    ) {
-      items {
-        id
-        entered
-        date
-        exerciseID
-        createdAt
-        updatedAt
-        _version
-        _deleted
-        _lastChangedAt
-      }
-      nextToken
-      startedAt
-    }
-  }
-`;
-export const entriesByExerciseID = /* GraphQL */ `
-  query EntriesByExerciseID(
-    $exerciseID: ID!
-    $sortDirection: ModelSortDirection
-    $filter: ModelEntryFilterInput
-    $limit: Int
-    $nextToken: String
-  ) {
-    entriesByExerciseID(
-      exerciseID: $exerciseID
-      sortDirection: $sortDirection
-      filter: $filter
-      limit: $limit
-      nextToken: $nextToken
-    ) {
-      items {
-        id
-        entered
-        date
-        exerciseID
-        createdAt
-        updatedAt
-        _version
-        _deleted
-        _lastChangedAt
-      }
-      nextToken
-      startedAt
-    }
-  }
-`;
-export const getExercise = /* GraphQL */ `
-  query GetExercise($id: ID!) {
-    getExercise(id: $id) {
+    items {
       id
-      title
-      total
-      Entries {
-        nextToken
-        startedAt
-      }
+      entered
+      date
+      exerciseID
       createdAt
       updatedAt
       _version
       _deleted
       _lastChangedAt
+      __typename
     }
+    nextToken
+    startedAt
+    __typename
   }
-`;
-export const listExercises = /* GraphQL */ `
-  query ListExercises(
-    $filter: ModelExerciseFilterInput
-    $limit: Int
-    $nextToken: String
+}
+` as GeneratedQuery<
+  APITypes.SyncEntriesQueryVariables,
+  APITypes.SyncEntriesQuery
+>;
+export const entriesByExerciseID = /* GraphQL */ `query EntriesByExerciseID(
+  $exerciseID: ID!
+  $sortDirection: ModelSortDirection
+  $filter: ModelEntryFilterInput
+  $limit: Int
+  $nextToken: String
+) {
+  entriesByExerciseID(
+    exerciseID: $exerciseID
+    sortDirection: $sortDirection
+    filter: $filter
+    limit: $limit
+    nextToken: $nextToken
   ) {
-    listExercises(filter: $filter, limit: $limit, nextToken: $nextToken) {
-      items {
-        id
-        title
-        total
-        createdAt
-        updatedAt
-        _version
-        _deleted
-        _lastChangedAt
-      }
+    items {
+      id
+      entered
+      date
+      exerciseID
+      createdAt
+      updatedAt
+      _version
+      _deleted
+      _lastChangedAt
+      __typename
+    }
+    nextToken
+    startedAt
+    __typename
+  }
+}
+` as GeneratedQuery<
+  APITypes.EntriesByExerciseIDQueryVariables,
+  APITypes.EntriesByExerciseIDQuery
+>;
+export const getExercise = /* GraphQL */ `query GetExercise($id: ID!) {
+  getExercise(id: $id) {
+    id
+    title
+    total
+    Entries {
       nextToken
       startedAt
+      __typename
     }
+    createdAt
+    updatedAt
+    _version
+    _deleted
+    _lastChangedAt
+    __typename
   }
-`;
-export const syncExercises = /* GraphQL */ `
-  query SyncExercises(
-    $filter: ModelExerciseFilterInput
-    $limit: Int
-    $nextToken: String
-    $lastSync: AWSTimestamp
+}
+` as GeneratedQuery<
+  APITypes.GetExerciseQueryVariables,
+  APITypes.GetExerciseQuery
+>;
+export const listExercises = /* GraphQL */ `query ListExercises(
+  $filter: ModelExerciseFilterInput
+  $limit: Int
+  $nextToken: String
+) {
+  listExercises(filter: $filter, limit: $limit, nextToken: $nextToken) {
+    items {
+      id
+      title
+      total
+      createdAt
+      updatedAt
+      _version
+      _deleted
+      _lastChangedAt
+      __typename
+    }
+    nextToken
+    startedAt
+    __typename
+  }
+}
+` as GeneratedQuery<
+  APITypes.ListExercisesQueryVariables,
+  APITypes.ListExercisesQuery
+>;
+export const syncExercises = /* GraphQL */ `query SyncExercises(
+  $filter: ModelExerciseFilterInput
+  $limit: Int
+  $nextToken: String
+  $lastSync: AWSTimestamp
+) {
+  syncExercises(
+    filter: $filter
+    limit: $limit
+    nextToken: $nextToken
+    lastSync: $lastSync
   ) {
-    syncExercises(
-      filter: $filter
-      limit: $limit
-      nextToken: $nextToken
-      lastSync: $lastSync
-    ) {
-      items {
-        id
-        title
-        total
-        createdAt
-        updatedAt
-        _version
-        _deleted
-        _lastChangedAt
-      }
-      nextToken
-      startedAt
+    items {
+      id
+      title
+      total
+      createdAt
+      updatedAt
+      _version
+      _deleted
+      _lastChangedAt
+      __typename
     }
+    nextToken
+    startedAt
+    __typename
   }
-`;
+}
+` as GeneratedQuery<
+  APITypes.SyncExercisesQueryVariables,
+  APITypes.SyncExercisesQuery
+>;

--- a/src/graphql/subscriptions.ts
+++ b/src/graphql/subscriptions.ts
@@ -2,102 +2,129 @@
 /* eslint-disable */
 // this is an auto generated file. This will be overwritten
 
-export const onCreateEntry = /* GraphQL */ `
-  subscription OnCreateEntry($filter: ModelSubscriptionEntryFilterInput) {
-    onCreateEntry(filter: $filter) {
-      id
-      entered
-      date
-      exerciseID
-      createdAt
-      updatedAt
-      _version
-      _deleted
-      _lastChangedAt
-    }
+import * as APITypes from "../API";
+type GeneratedSubscription<InputType, OutputType> = string & {
+  __generatedSubscriptionInput: InputType;
+  __generatedSubscriptionOutput: OutputType;
+};
+
+export const onCreateEntry = /* GraphQL */ `subscription OnCreateEntry($filter: ModelSubscriptionEntryFilterInput) {
+  onCreateEntry(filter: $filter) {
+    id
+    entered
+    date
+    exerciseID
+    createdAt
+    updatedAt
+    _version
+    _deleted
+    _lastChangedAt
+    __typename
   }
-`;
-export const onUpdateEntry = /* GraphQL */ `
-  subscription OnUpdateEntry($filter: ModelSubscriptionEntryFilterInput) {
-    onUpdateEntry(filter: $filter) {
-      id
-      entered
-      date
-      exerciseID
-      createdAt
-      updatedAt
-      _version
-      _deleted
-      _lastChangedAt
-    }
+}
+` as GeneratedSubscription<
+  APITypes.OnCreateEntrySubscriptionVariables,
+  APITypes.OnCreateEntrySubscription
+>;
+export const onUpdateEntry = /* GraphQL */ `subscription OnUpdateEntry($filter: ModelSubscriptionEntryFilterInput) {
+  onUpdateEntry(filter: $filter) {
+    id
+    entered
+    date
+    exerciseID
+    createdAt
+    updatedAt
+    _version
+    _deleted
+    _lastChangedAt
+    __typename
   }
-`;
-export const onDeleteEntry = /* GraphQL */ `
-  subscription OnDeleteEntry($filter: ModelSubscriptionEntryFilterInput) {
-    onDeleteEntry(filter: $filter) {
-      id
-      entered
-      date
-      exerciseID
-      createdAt
-      updatedAt
-      _version
-      _deleted
-      _lastChangedAt
-    }
+}
+` as GeneratedSubscription<
+  APITypes.OnUpdateEntrySubscriptionVariables,
+  APITypes.OnUpdateEntrySubscription
+>;
+export const onDeleteEntry = /* GraphQL */ `subscription OnDeleteEntry($filter: ModelSubscriptionEntryFilterInput) {
+  onDeleteEntry(filter: $filter) {
+    id
+    entered
+    date
+    exerciseID
+    createdAt
+    updatedAt
+    _version
+    _deleted
+    _lastChangedAt
+    __typename
   }
-`;
-export const onCreateExercise = /* GraphQL */ `
-  subscription OnCreateExercise($filter: ModelSubscriptionExerciseFilterInput) {
-    onCreateExercise(filter: $filter) {
-      id
-      title
-      total
-      Entries {
-        nextToken
-        startedAt
-      }
-      createdAt
-      updatedAt
-      _version
-      _deleted
-      _lastChangedAt
+}
+` as GeneratedSubscription<
+  APITypes.OnDeleteEntrySubscriptionVariables,
+  APITypes.OnDeleteEntrySubscription
+>;
+export const onCreateExercise = /* GraphQL */ `subscription OnCreateExercise($filter: ModelSubscriptionExerciseFilterInput) {
+  onCreateExercise(filter: $filter) {
+    id
+    title
+    total
+    Entries {
+      nextToken
+      startedAt
+      __typename
     }
+    createdAt
+    updatedAt
+    _version
+    _deleted
+    _lastChangedAt
+    __typename
   }
-`;
-export const onUpdateExercise = /* GraphQL */ `
-  subscription OnUpdateExercise($filter: ModelSubscriptionExerciseFilterInput) {
-    onUpdateExercise(filter: $filter) {
-      id
-      title
-      total
-      Entries {
-        nextToken
-        startedAt
-      }
-      createdAt
-      updatedAt
-      _version
-      _deleted
-      _lastChangedAt
+}
+` as GeneratedSubscription<
+  APITypes.OnCreateExerciseSubscriptionVariables,
+  APITypes.OnCreateExerciseSubscription
+>;
+export const onUpdateExercise = /* GraphQL */ `subscription OnUpdateExercise($filter: ModelSubscriptionExerciseFilterInput) {
+  onUpdateExercise(filter: $filter) {
+    id
+    title
+    total
+    Entries {
+      nextToken
+      startedAt
+      __typename
     }
+    createdAt
+    updatedAt
+    _version
+    _deleted
+    _lastChangedAt
+    __typename
   }
-`;
-export const onDeleteExercise = /* GraphQL */ `
-  subscription OnDeleteExercise($filter: ModelSubscriptionExerciseFilterInput) {
-    onDeleteExercise(filter: $filter) {
-      id
-      title
-      total
-      Entries {
-        nextToken
-        startedAt
-      }
-      createdAt
-      updatedAt
-      _version
-      _deleted
-      _lastChangedAt
+}
+` as GeneratedSubscription<
+  APITypes.OnUpdateExerciseSubscriptionVariables,
+  APITypes.OnUpdateExerciseSubscription
+>;
+export const onDeleteExercise = /* GraphQL */ `subscription OnDeleteExercise($filter: ModelSubscriptionExerciseFilterInput) {
+  onDeleteExercise(filter: $filter) {
+    id
+    title
+    total
+    Entries {
+      nextToken
+      startedAt
+      __typename
     }
+    createdAt
+    updatedAt
+    _version
+    _deleted
+    _lastChangedAt
+    __typename
   }
-`;
+}
+` as GeneratedSubscription<
+  APITypes.OnDeleteExerciseSubscriptionVariables,
+  APITypes.OnDeleteExerciseSubscription
+>;

--- a/src/models/schema.js
+++ b/src/models/schema.js
@@ -167,6 +167,6 @@ export const schema = {
     },
     "enums": {},
     "nonModels": {},
-    "codegenVersion": "3.4.0",
+    "codegenVersion": "3.4.4",
     "version": "f9a27381afbc1079a3536515b30569d4"
 };

--- a/src/pages/ExerciseScreen.tsx
+++ b/src/pages/ExerciseScreen.tsx
@@ -66,25 +66,6 @@ const ExerciseScreen = ({ navigation, route }: PropTypes) => {
     );
   };
 
-  // <SlidingListItem
-  //       item={item}
-  //       onDelete={() => console.log("delete")}
-  //       onEdit={() => console.log("onEdit")}
-  //     >
-  //       <View>
-  //         <Text>HERE</Text>
-  //       </View>
-  //     </SlidingListItem>
-
-  {
-    /*  <EntryListItem
-          item={item}
-          onPress={() => navigation.navigate("")}
-          itemIndex={item.index}
-          entries={entries}
-        />*/
-  }
-
   return (
     <View style={styles.container}>
       <SectionHeading>{exercise.title}</SectionHeading>
@@ -115,7 +96,7 @@ const ExerciseScreen = ({ navigation, route }: PropTypes) => {
           })}
         />
       ) : (
-        <Text>No Entries</Text>
+        <Text>Loading</Text>
       )}
     </View>
   );

--- a/src/pages/components/SlidingListItem.tsx
+++ b/src/pages/components/SlidingListItem.tsx
@@ -1,3 +1,4 @@
+// import { Icon } from "@aws-amplify/ui-react-native/dist/primitives";
 import React, { useState, useRef } from "react";
 import {
   View,
@@ -6,6 +7,7 @@ import {
   Animated,
   StyleSheet,
 } from "react-native";
+import Icon from "@expo/vector-icons/MaterialCommunityIcons";
 
 const deleteButtonWidth = 85;
 
@@ -47,8 +49,11 @@ const SlidingListItem = ({ item, onDelete }) => {
           onPress={handleItemPress}
           activeOpacity={isOpen ? 1 : 0.8}
         >
-          <Text style={styles.itemText}>{item.entered}</Text>
+          <Text style={styles.itemText}>
+            {item.entered} {item.entered > 1 ? "reps" : "rep"}
+          </Text>
           <Text style={styles.itemText}>{item.date}</Text>
+          <Icon name="drag-vertical" size={32} />
         </TouchableOpacity>
       </Animated.View>
 
@@ -71,11 +76,14 @@ const styles = StyleSheet.create({
     marginHorizontal: 20,
     borderRadius: 8,
     zIndex: 2,
+    cursor: "pointer",
   },
   itemContent: {
     flex: 1,
     flexDirection: "row",
     padding: 16,
+    justifyContent: "space-between",
+    alignItems: "center",
   },
   itemText: {
     marginLeft: 20,


### PR DESCRIPTION
Implement a sliding entry item on the exercise page.

Update API key: Amplify has an issue when an API key expires, where you can not update the API key even if you change the export file. To fix this, I added "CreateAPIKey" and set that to 0. Then ran `amplify push`. That deleted the stagnant API Key. After that, I changed "CreateAPIKey" to 1 and pushed. Then I was able to run `amplify update api` connecting my app to my staging data.